### PR TITLE
Remove trailing space in 5 star link

### DIFF
--- a/admin/class-leira-roles-admin.php
+++ b/admin/class-leira-roles-admin.php
@@ -705,9 +705,7 @@ class Leira_Roles_Admin{
                 <a href="https://wordpress.org/support/plugin/leira-roles/reviews/?filter=5" target="_blank"
                    class="leira-roles-admin-rating-link"
                    data-rated="<?php esc_attr_e( 'Thanks :)', 'leira-roles' ) ?>"
-                   data-nonce="<?php echo wp_create_nonce( 'footer-rated' ) ?>">
-                    &#9733;&#9733;&#9733;&#9733;&#9733;
-                </a>
+                   data-nonce="<?php echo wp_create_nonce( 'footer-rated' ) ?>">&#9733;&#9733;&#9733;&#9733;&#9733;</a>
 				<?php $link = ob_get_clean();
 
 				ob_start();


### PR DESCRIPTION
It's unfortunately not as pretty in the code but I think the pros outweigh the cons here.

Before:
![image](https://user-images.githubusercontent.com/45571053/114728306-4620fe80-9d3f-11eb-93fd-91085a4c24bd.png)

After:
![image](https://user-images.githubusercontent.com/45571053/114728239-36a1b580-9d3f-11eb-8f08-7c49d94a6918.png)

